### PR TITLE
Compatibility with IPython 7

### DIFF
--- a/rlipython/shell.py
+++ b/rlipython/shell.py
@@ -554,8 +554,9 @@ class TerminalInteractiveShell(InteractiveShell):
                 #double-guard against keyboardinterrupts during kbdint handling
                 try:
                     self.write('\n' + self.get_exception_only())
-                    source_raw = ''.join(self.lines_waiting)
+                    source_raw = '\n'.join(self.lines_waiting)
                     self.lines_waiting = []
+                    self._indent_spaces = None
                     hlen_b4_cell = \
                         self._replace_rlhist_multiline(source_raw, hlen_b4_cell)
                     more = False
@@ -580,7 +581,7 @@ class TerminalInteractiveShell(InteractiveShell):
             else:
                 try:
                     self.lines_waiting.append(line)
-                    status, next_indent = self.input_splitter.check_complete(''.join(self.lines_waiting))
+                    status, next_indent = self.input_splitter.check_complete('\n'.join(self.lines_waiting))
                     self._indent_spaces = next_indent
                     more = status == 'incomplete'
                 except SyntaxError:
@@ -591,7 +592,7 @@ class TerminalInteractiveShell(InteractiveShell):
                     self.autoedit_syntax):
                     self.edit_syntax_error()
                 if not more:
-                    source_raw = ''.join(self.lines_waiting)
+                    source_raw = '\n'.join(self.lines_waiting)
                     self.lines_waiting = []
                     self.run_cell(source_raw, store_history=True)
                     hlen_b4_cell = \

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ setup(
     name='rlipython',
     version='0.1.2',
     packages=['rlipython',],
-    install_requires=["ipython>5.3"],
+    install_requires=["ipython>=7.0.0"],
     extras_requires=extras_requires,
     license='BSD',
     author='The IPython Development Team',
     author_email='ipython-dev@python.org',
     url='https://github.com/ipython/rlipython',
-    description="readline integration for IPython 5.4+ and 6.0+",
+    description="readline integration for IPython 7.0+",
     long_description=description
 )


### PR DESCRIPTION
Some minor revisions to accommodate changes made with Ipython7 swapping from IPython.core.inputsplitter to IPython.core.inputtransformer2.

I believe this closes #21 
