### PR TITLE
Added colorama for interpretation of ansi escape sequences in windows

### DIFF
--- a/rlipython/shell.py
+++ b/rlipython/shell.py
@@ -10,6 +10,8 @@ import bdb
 import os
 import sys
 
+import colorama
+
 from IPython.utils.strdispatch import StrDispatch
 
 from IPython.core.error import TryNext, UsageError
@@ -27,6 +29,8 @@ from warnings import warn
 from IPython.utils.text import num_ini_spaces
 from traitlets import Integer, CBool, Unicode, default
 
+
+colorama.init()
 
 def get_default_editor():
     try:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     name='rlipython',
     version='0.1.2',
     packages=['rlipython',],
-    install_requires=["ipython>5.3"],
+    install_requires=["colorama", "ipython>5.3"],
     extras_requires=extras_requires,
     license='BSD',
     author='The IPython Development Team',


### PR DESCRIPTION
This resolves the issues as reported in #23 for windows powershell whilst leaving other platforms unaffected.